### PR TITLE
tag cloud

### DIFF
--- a/lib/tag_columns.rb
+++ b/lib/tag_columns.rb
@@ -32,6 +32,15 @@ module TagColumns
           connection.execute(query.to_sql).values.flatten.sort
         end
 
+        define_singleton_method :"#{method_name}_cloud" do |conditions = "true"|
+          unnest = Arel::Nodes::NamedFunction.new("unnest", [arel_table[column_name]])
+          query = unscoped.select(unnest.as("tag")).
+            where(conditions).
+            where.not(arel_table[column_name].eq(nil)).
+            where.not(arel_table[column_name].eq("{}"))
+          from(query).group("tag").order("tag").pluck(Arel.sql("tag, count(*) as count"))
+        end
+
         scope :"with_#{method_name}", -> {
           where.not(arel_table[column_name].eq(nil)).where.not(arel_table[column_name].eq("{}"))
         }


### PR DESCRIPTION
This patch adds a singleton method to the model class which supports generating an array of weighted arrays, tallying unique values present on the table.

```ruby
`Post.keywords_cloud`
```
results in:
`[["DOM", 1],
 ["actioncable", 1],
 ["ajax", 2],
 ["app-bridge", 1],
 ["binding", 1],
 ["bootstrap", 1],
 ["bulma", 1],
 ["cable", 1],
 ["check-all", 1],
 ["checkbox", 1],
 ["commands", 1],
 ["components", 3],
 ["controller", 11]]`

Method supports AR scopes, similar to `Post.unique_keywords`.