### PR TITLE
Do not raise error when column value is nil

### DIFF
--- a/lib/tag_columns.rb
+++ b/lib/tag_columns.rb
@@ -7,6 +7,7 @@ module TagColumns
 
   module ClassMethods
     def tag_columns_sanitize_list(values = [])
+      return [] if values.nil?
       values.select(&:present?).map(&:to_s).uniq.sort
     end
 
@@ -81,7 +82,7 @@ module TagColumns
           where.not contains
         }
 
-        before_validation -> { self[column_name] = self.class.tag_columns_sanitize_list(self[column_name] || []) }
+        before_validation -> { self[column_name] = self.class.tag_columns_sanitize_list(self[column_name]) }
 
         define_method :"has_any_#{method_name}?" do |*values|
           values = self.class.tag_columns_sanitize_list(values)

--- a/lib/tag_columns.rb
+++ b/lib/tag_columns.rb
@@ -81,7 +81,7 @@ module TagColumns
           where.not contains
         }
 
-        before_validation -> { self[column_name] = self.class.tag_columns_sanitize_list(self[column_name]) }
+        before_validation -> { self[column_name] = self.class.tag_columns_sanitize_list(self[column_name] || []) }
 
         define_method :"has_any_#{method_name}?" do |*values|
           values = self.class.tag_columns_sanitize_list(values)


### PR DESCRIPTION
This fix will resolve issues where a column may not have an established value yet, and therefore cannot save.